### PR TITLE
Update btfm_slim.c

### DIFF
--- a/drivers/bluetooth/btfm_slim.c
+++ b/drivers/bluetooth/btfm_slim.c
@@ -23,7 +23,7 @@
 #include <sound/soc.h>
 #include <sound/soc-dapm.h>
 #include <sound/tlv.h>
-#include <btfm_slim.h>
+#include "btfm_slim.h"
 #include <btfm_slim_wcn3990.h>
 #include <linux/bluetooth-power.h>
 


### PR DESCRIPTION
Fixing drivers/bluetooth/btfm_slim.c:26:10: fatal error: btfm_slim.h: No such file or directory